### PR TITLE
Use Constant VUs executor for stress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ __n__ is equal to 20% of the user count that the instance supports before it ram
 
 ### Search Performance Test
 
+Test duration: ~32m
+
 The test runs the same set of queries for each search type 30 times respectively, with a max duration set as 32 minutes.
 
 From the end-of-test summary, we can see how long it takes for each type of search to be executed by looking at the time for first byte metrics for 95% of the requests P(95).
@@ -65,6 +67,8 @@ k6 run scripts/search.js
 
 ### Load Test
 
+Test duration: ~10m
+
 The load test ramps up from 0 to __n__ concurrent users (see n-users table above) over 2 minutes, and stays at __n__ concurrent users for 6 minutes, before ramping back down to 0 in 2 minutes. Each virtual user would send a a random request to one of the instance endpoints at a random time over the test duration with the following distribution: 
 - 40% of the VUs -GET request to frontpage
 - 30% of the VUs -POST request to the graphQL API endpoint with a random literal search query
@@ -84,6 +88,8 @@ k6 run -e SG_SIZE=<size> scripts/load.js
 ```
 
 ### Stress Test
+
+Test duration: ~1m
 
 The stress test runs the same script as the load test aggressively in a short time period. 
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ k6 run scripts/search.js
 
 ### Load Test
 
-The load test starts with 0 concurrent virtual users (VUs) and ramps up gradually to __n__ users (see n-users table above) before ramping back down to 0. Each virtual user would send one random request to one of the instance endpoints, with a random sleep time (1 - 60 seconds) in-between: 
+The load test starts with 0 concurrent virtual users (VUs) and ramps up gradually to __n__ users (see n-users table above) before ramping back down to 0. Each virtual user would send one random request to one of the instance endpoints, with a random sleep time (1 - 60 seconds) in-between requests: 
 - 40% of the VUs send a POST request to the graphQL API endpoint with a random literal search query
 - 30% of the VUs send a GET request to frontpage
 - 20% of the VUs send a POST request to the graphQL API endpoint with a random regexp search query
@@ -85,9 +85,9 @@ k6 run -e SG_SIZE=<size> scripts/load.js
 
 The stress test runs the same script as the load test aggressively in a short time period. 
 
-The test tries to overwhelm the system with an extreme surge of load by ramping up from 0 to __n__ users in 20 seconds, where each user sends a random request to the instance concurrently, with a shorter random start time and sleep time in between for another 30 seconds. 
+The test tries to overwhelm the system with an extreme surge of load by having __n__ concurrent users sending random requests at random times to the instance for 60 seconds.
 
-> Note: The response time of a stress test is expected to be slower than usual, as we should rather focus on the request failing rate instead. Therefore, we should look at the request failure ratio (http_req_failed) in the end-of-test summary. The successful-calls (check) ratio for a well-performing instance should be above 90%.
+> Note: The response times in a stress test is expected to be slower than usual, as we should rather focus on the request failing rate instead. Therefore, we should look at the request failure ratio (http_req_failed) in the end-of-test summary. The successful-calls (check) ratio for a well-performing instance should be above 90%.
 
 To start a stress test, run the following command at the root of this repository:
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ k6 run scripts/search.js
 
 ### Load Test
 
-The load test starts with 0 concurrent virtual users (VUs) and ramps up gradually to __n__ users (see n-users table above) before ramping back down to 0. Each virtual user would send one random request to one of the instance endpoints, with a random sleep time (1 - 60 seconds) in-between requests: 
-- 40% of the VUs send a POST request to the graphQL API endpoint with a random literal search query
-- 30% of the VUs send a GET request to frontpage
-- 20% of the VUs send a POST request to the graphQL API endpoint with a random regexp search query
-- 10% of the VUs send a GET request to the stream search API endpoint with a random search query
+The load test ramps up from 0 to __n__ concurrent users (see n-users table above) over 2 minutes, and stays at __n__ concurrent users for 6 minutes, before ramping back down to 0 in 2 minutes. Each virtual user would send a a random request to one of the instance endpoints at a random time over the test duration with the following distribution: 
+- 40% of the VUs -GET request to frontpage
+- 30% of the VUs -POST request to the graphQL API endpoint with a random literal search query
+- 20% of the VUs -POST request to the graphQL API endpoint with a random regexp search query
+- 10% of the VUs -GET request to the stream search API endpoint with a random search query
+
+This distrubtion is based on our data, where about 70% of all the searches performed are literal search, and 1-2% are structural and unindexed searches. 
 
 The result shows us how the instance performs under both normal and peak load.
 

--- a/scripts/load.js
+++ b/scripts/load.js
@@ -35,40 +35,33 @@ export function setup() {
 export default function () {
   if (__VU % 10 == 1) {
     // 10% of the VUs perform a random search request chosen from any search types
+    // it has the longest sleep time as structural and unindexed searches are
+    // the least commonly performed search types
     group('stream', function () {
-      sleep(randomIntBetween(1, 60));
+      sleep(randomIntBetween(1, 240));
       const searchType = randomItem(searchQueries.types);
       const tags = { tag: { type: searchType } };
       const searchQuery = randomItem(searchQueries[searchType]);
       const streamEndpoint = makeStreamEndpoint(searchQuery);
       const res = http.get(streamEndpoint, params, tags);
       processResponse(res, tags);
-      sleep(randomIntBetween(0, 30));
+      sleep(randomIntBetween(1, 240));
     });
   } else if (__VU % 10 == 2) {
     // 20% of the VUs performs regexp searches
     group('graphQL - Regexp', function () {
-      sleep(randomIntBetween(1, 60));
+      sleep(randomIntBetween(1, 120));
       const searchType = 'regexp';
       const tags = { tag: { type: searchType } };
       const searchQuery = randomItem(searchQueries[searchType]);
       const body = makeGraphQLQuery('search', searchQuery.query);
       const res = http.post(graphqlEndpoint, body, params, tags);
       processResponse(res, tags);
-      sleep(randomIntBetween(0, 30));
+      sleep(randomIntBetween(1, 120));
     });
   } else if (__VU % 10 == 3) {
-    // 30% of the VUs hitting frontpage
-    group('frontpage', function () {
-      sleep(randomIntBetween(0, 60));
-      const searchType = 'frontpage';
-      const tags = { tag: { type: searchType } };
-      const res = http.get(uri, null, tags);
-      processResponse(res, tags);
-      sleep(randomIntBetween(0, 30));
-    });
-  } else {
-    // the rest of the VUs (40%) performs literal searches
+    // 30% of the VUs performs literal searches with a shorter sleep time
+    // as it is the most commonly performed searches
     group('graphQL - Literal', function () {
       sleep(randomIntBetween(1, 60));
       const searchType = 'literal';
@@ -77,7 +70,20 @@ export default function () {
       const body = makeGraphQLQuery('search', searchQuery.query);
       const res = http.post(graphqlEndpoint, body, params, tags);
       processResponse(res, tags);
-      sleep(randomIntBetween(0, 30));
+      sleep(randomIntBetween(1, 60));
+    });
+  } else {
+    // the rest of the VUs (40%) hits frontpage
+    // this stimulates users hitting the site in browser
+    // it also has the shortest sleep time as more users spend more time
+    // browsing results and pages than performing searches
+    group('frontpage', function () {
+      sleep(randomIntBetween(1, 30));
+      const searchType = 'frontpage';
+      const tags = { tag: { type: searchType } };
+      const res = http.get(uri, null, tags);
+      processResponse(res, tags);
+      sleep(randomIntBetween(1, 30));
     });
   }
 }

--- a/scripts/options/load.json
+++ b/scripts/options/load.json
@@ -2,43 +2,25 @@
   "s": {
     "discardResponseBodies": true,
     "stages": [
-      { "duration": "2m", "target": 500 },
-      { "duration": "5m", "target": 500 },
-      { "duration": "2m", "target": 1000 },
-      { "duration": "5m", "target": 1000 },
-      { "duration": "2m", "target": 1500 },
-      { "duration": "5m", "target": 1500 },
       { "duration": "2m", "target": 2000 },
-      { "duration": "30s", "target": 2000 },
-      { "duration": "30s", "target": 0 }
+      { "duration": "6m", "target": 2000 },
+      { "duration": "2m", "target": 0 }
     ]
   },
   "m": {
     "discardResponseBodies": true,
     "stages": [
-      { "duration": "2m", "target": 500 },
-      { "duration": "5m", "target": 1000 },
-      { "duration": "2m", "target": 2000 },
-      { "duration": "5m", "target": 2000 },
-      { "duration": "2m", "target": 3000 },
-      { "duration": "5m", "target": 3000 },
       { "duration": "2m", "target": 4000 },
-      { "duration": "30s", "target": 4000 },
-      { "duration": "30s", "target": 0 }
+      { "duration": "6m", "target": 4000 },
+      { "duration": "2m", "target": 0 }
     ]
   },
   "l": {
     "discardResponseBodies": true,
     "stages": [
-      { "duration": "2m", "target": 1500 },
-      { "duration": "5m", "target": 3000 },
-      { "duration": "2m", "target": 6000 },
-      { "duration": "5m", "target": 8000 },
-      { "duration": "2m", "target": 8000 },
-      { "duration": "5m", "target": 10000 },
       { "duration": "2m", "target": 12000 },
-      { "duration": "30s", "target": 12000 },
-      { "duration": "30s", "target": 0 }
+      { "duration": "6m", "target": 12000 },
+      { "duration": "2m", "target": 0 }
     ]
   }
 }

--- a/scripts/options/stress.json
+++ b/scripts/options/stress.json
@@ -1,26 +1,35 @@
 {
   "s": {
     "discardResponseBodies": true,
-    "stages": [
-      { "duration": "30s", "target": 2000 },
-      { "duration": "30s", "target": 2000 }
-    ],
-    "rps": 2000
+    "scenarios": {
+      "stress": {
+        "executor": "constant-vus",
+        "vus": 2000,
+        "duration": "60s",
+        "gracefulStop": "3s"
+      }
+    }
   },
   "m": {
     "discardResponseBodies": true,
-    "stages": [
-      { "duration": "30s", "target": 4000 },
-      { "duration": "30s", "target": 4000 }
-    ],
-    "rps": 4000
+    "scenarios": {
+      "stress": {
+        "executor": "constant-vus",
+        "vus": 4000,
+        "duration": "60s",
+        "gracefulStop": "3s"
+      }
+    }
   },
   "l": {
     "discardResponseBodies": true,
-    "stages": [
-      { "duration": "30s", "target": 12000 },
-      { "duration": "30s", "target": 12000 }
-    ],
-    "rps": 12000
+    "scenarios": {
+      "stress": {
+        "executor": "constant-vus",
+        "vus": 12000,
+        "duration": "60s",
+        "gracefulStop": "3s"
+      }
+    }
   }
 }


### PR DESCRIPTION
In this PR

## Stress test

Update script to use the [Constant VUs executor](https://k6.io/docs/using-k6/scenarios/executors/constant-vus/).

## Load test

I believe the current script does not reflect a natural user behavior as each user is performing searches frequently (where in reality, users would perform a search and take some time to look at the results before making another search), so I have increased the sleep times between search requests for each user and increased the frequency of hitting the frontpage instead of performing literal searches.

