### PR TITLE
Update http timeout

### DIFF
--- a/scripts/utils/helpers.js
+++ b/scripts/utils/helpers.js
@@ -23,8 +23,10 @@ export const instanceSize = __ENV.SG_SIZE
   : endpointSettings.size.toLowerCase();
 export const graphqlEndpoint = new URL('/.api/graphql', uri).toString();
 const headers = { Authorization: `token ${accessToken}` };
-export const params = { headers };
-
+export const params = {
+  headers,
+  timeout: "70s", // 60s backend timeout + 10s buffer for RTT
+};
 // IMPORT SEARCH QUERIES FROM JSON
 // search queries for load test - load.js script
 export const searchQueries =


### PR DESCRIPTION
Update k6 http timeout to add buffer for RTT - our backend timeout is 60s, so using the default client timeout of 60s can cause timeouts for requests that completed on the server within the intended 60s. 

We have checks to assure latency matches our expectations, so this shouldn't influence correctness.