### PR TITLE
Print a small error message indicating to define repos. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ Types of searches:
 - structural search - example: 'repo:^github.com/sourcegraph/sourcegraph$ try { :[matched_statements] } catch { :[matched_catch] } patternType:structural'
 - unindexed search - example: 'repo:^github.com/sourcegraph/sourcegraph$ type:diff TODO select:commit.diff.removed'
 
-### n-users
+### Size Chart
+
+#### n-users
 
 __n__ is equal to 20% of the user count that the instance supports before it ramps back down to 0.
 
 | Size   | Users | n (expected users) |
 |--------|-------|--------------------|
-| L      | 10000 | 2000               |
-| XL     | 20000 | 4000               |
-| XXL    | 60000 | 12000              |
-| XXXL   | -     | -                  |
+| S      | 10000 | 2000               |
+| M      | 20000 | 4000               |
+| L      | 60000 | 12000              |
+| XL.    | -     | -                  |
 
 ### Search Performance Test
 

--- a/scripts/utils/queryGenerator.js
+++ b/scripts/utils/queryGenerator.js
@@ -8,7 +8,7 @@ const queryComponents = JSON.parse(
 );
 const repos = userSettings.repos;
 if (!repos) {
-  console.log("no repos are defined, please edit '.settings.json'")
+  console.log("No repos are defined, please edit '.settings.json'\nSee README.md for more details.")
   process.exit(1)
 }
 

--- a/scripts/utils/queryGenerator.js
+++ b/scripts/utils/queryGenerator.js
@@ -7,6 +7,11 @@ const queryComponents = JSON.parse(
   fs.readFileSync('scripts/utils/generator.json').toString()
 );
 const repos = userSettings.repos;
+if (!repos) {
+  console.log("no repos are defined, please edit '.settings.json'")
+  process.exit(1)
+}
+
 if (repos.length > 1) {
   const newQueries = {
     literal: [],


### PR DESCRIPTION
As I was looking to get some test queries, I got slightly confused for a minute by the error message. This small PR will at least avoid the next teammate in a hurry to be confused, even though everyone should read READMEs carefully before doing anything 🤣 !

Test Plan: locally tested. 

Before: 

```
~/work/esceng/k6  main $ node ./scripts/utils/queryGenerator.js
file:///Users/tech/work/esceng/k6/scripts/utils/queryGenerator.js:10
if (repos.length > 1) {
          ^

TypeError: Cannot read properties of undefined (reading 'length')
    at file:///Users/tech/work/esceng/k6/scripts/utils/queryGenerator.js:10:11
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:385:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12)
```

After: 

```
~/work/esceng/k6 U jh/error-msg-repos $ node ./scripts/utils/queryGenerator.js
No repos are defined, please edit '.settings.json'
See README.md for more details.
```